### PR TITLE
Fix remote URLs and popup route

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://localhost:4000/api',
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:4000/api',
   headers: {
     'Content-Type': 'application/json'
   }

--- a/frontend/src/components/ForgotPasswordModal.jsx
+++ b/frontend/src/components/ForgotPasswordModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { X, Mail, Send } from 'lucide-react';
-import axios from 'axios';
+import api from '../api';
 
 const ForgotPasswordModal = ({
   onClose,
@@ -24,7 +24,7 @@ const ForgotPasswordModal = ({
 
     try {
       // Simulazione invio email
-      await axios.post('http://localhost:4000/api/auth/forgot-password', { email });
+      await api.post('/auth/forgot-password', { email });
       setIsSubmitted(true);
       setError('');
     } catch (err) {

--- a/frontend/src/components/LoginModal.jsx
+++ b/frontend/src/components/LoginModal.jsx
@@ -109,7 +109,7 @@ const LoginModal = ({
       
       if (openInPopup) {
         // Apri in popup
-        const popup = window.open('/land', '_blank', 'width=1200,height=800,scrollbars=yes,resizable=yes');
+        const popup = window.open('/#/land', '_blank', 'width=1200,height=800,scrollbars=yes,resizable=yes');
         if (popup) {
           popup.focus();
           onClose();

--- a/frontend/src/hooks/usePresenze.js
+++ b/frontend/src/hooks/usePresenze.js
@@ -67,7 +67,10 @@ export default function usePresenze() {
     const connectWebSocket = () => {
       try {
         // Prova a connettersi al WebSocket
-        ws = new WebSocket('ws://localhost:4000/ws/presenze');
+        const wsUrl =
+          (import.meta.env.VITE_WS_URL || 'ws://localhost:4000') +
+          '/ws/presenze';
+        ws = new WebSocket(wsUrl);
         
         ws.onopen = () => {
           console.log('WebSocket connesso per presenze');

--- a/frontend/src/pages/LandPage.jsx
+++ b/frontend/src/pages/LandPage.jsx
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useContext } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { UserContext } from '../contexts/UserContext';
 
 const LandPage = () => {
@@ -10,15 +10,7 @@ const LandPage = () => {
     const setOnline = async () => {
       if (user && user.token) {
         try {
-          await axios.post(
-            'http://localhost:4000/api/presenze/online',
-            {},
-            {
-              headers: {
-                Authorization: `Bearer ${user.token}`,
-              },
-            }
-          );
+          await api.post('/presenze/online');
           console.log('✅ Stato online aggiornato');
         } catch (error) {
           console.error('❌ Errore impostando online:', error);


### PR DESCRIPTION
## Summary
- support configurable API base URL in axios client
- update Land page to use axios instance
- use axios instance for forgot-password
- allow websocket URL via env var
- open Land popup using hash-based routing

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68444af3a6a48322be6922a41c912b14