### PR TITLE
Add editable documentation and admin management

### DIFF
--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -24,12 +24,13 @@ router.post('/login', async (req, res) => {
     console.log(`${user.nome} ${user.cognome} è entrato nella Piazza Centrale`);
 
     const token = generateToken(user.id);
-    res.json({ 
+    res.json({
       token,
       user: {
         nome: user.nome,
         cognome: user.cognome,
-        location: user.current_location
+        location: user.current_location,
+        role: user.role
       }
     });
   } catch (error) {

--- a/frontend/src/components/DocumentationModal.jsx
+++ b/frontend/src/components/DocumentationModal.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { X } from 'lucide-react';
+import { loadDocumentation } from '../data/documentation';
 
 function DocumentationModal({
   onClose,
@@ -9,23 +10,38 @@ function DocumentationModal({
   setDragOffset,
   setIsDragging,
   onFocus,
-  zIndex,
-  scrollToSection
+  zIndex
 }) {
+  const [section, setSection] = useState('caratteristiche');
+  const docs = loadDocumentation();
+
   const handleMouseDown = (e) => {
-    // Prevent dragging when clicking on scrollable content
-    if (e.target.closest('.scrollable-content')) {
-      return;
-    }
-    
+    if (e.target.closest('.scrollable-content')) return;
     setIsDragging('documentation');
-    setDragOffset({
-      x: e.clientX - position.x,
-      y: e.clientY - position.y,
-    });
+    setDragOffset({ x: e.clientX - position.x, y: e.clientY - position.y });
     onFocus('documentation');
     e.preventDefault();
   };
+
+  const renderContent = () => {
+    switch (section) {
+      case 'caratteristiche':
+        return <div className="whitespace-pre-wrap">{docs.caratteristiche}</div>;
+      case 'abilita':
+        return <div className="whitespace-pre-wrap">{docs.abilita}</div>;
+      case 'creazione':
+        return <div className="whitespace-pre-wrap">{docs.creazione}</div>;
+      case 'regole':
+        return <div className="whitespace-pre-wrap">{docs.regole}</div>;
+      default:
+        return null;
+    }
+  };
+
+  const itemClasses = (key) =>
+    `block w-full text-left px-2 py-1 rounded ${
+      section === key ? 'text-cyan-400' : 'text-cyan-200 hover:text-cyan-100'
+    }`;
 
   return (
     <div
@@ -34,167 +50,31 @@ function DocumentationModal({
         top: position.y,
         left: position.x,
         zIndex: zIndex || 40,
-        cursor: isDragging === 'documentation' ? 'grabbing' : 'grab',
+        cursor: isDragging === 'documentation' ? 'grabbing' : 'grab'
       }}
       onMouseDown={onFocus}
     >
-      <div 
+      <div
         className="flex justify-between items-center p-6 pb-4 cursor-grab"
         onMouseDown={handleMouseDown}
       >
         <h2 className="text-xl font-bold text-cyan-400">DOCUMENTAZIONE</h2>
-        <button 
+        <button
           onClick={onClose}
           className="text-cyan-400 hover:text-red-400 transition-colors"
         >
           <X size={18} />
         </button>
       </div>
-
-      <div className="scrollable-content px-6 pb-6 h-[calc(100%-60px)] overflow-y-auto custom-scrollbar">
-        <div className="space-y-6">
-          {/* Sezione 1: Caratteristiche Base */}
-          <div className="border-b border-cyan-600/20 pb-6">
-            <h2 className="text-lg font-bold text-cyan-300 mb-4">Caratteristiche Base</h2>
-            <div className="space-y-4 text-cyan-200 text-sm">
-              <div id="forza">
-                <h3 className="text-cyan-400 font-semibold mb-2">Forza</h3>
-                <ul className="list-disc list-inside space-y-1 ml-2">
-                  <li>1 - Sotto la media</li>
-                  <li>2 - Media</li>
-                  <li>3 - Forte</li>
-                  <li>4 - Molto forte</li>
-                  <li>5 - Eccezionale</li>
-                </ul>
-              </div>
-              
-              <div id="destrezza">
-                <h3 className="text-cyan-400 font-semibold mb-2">Destrezza</h3>
-                <ul className="list-disc list-inside space-y-1 ml-2">
-                  <li>1 - Goffo</li>
-                  <li>2 - Normale</li>
-                  <li>3 - Agile</li>
-                  <li>4 - Molto agile</li>
-                  <li>5 - Acrobata</li>
-                </ul>
-              </div>
-              
-              <div id="costituzione">
-                <h3 className="text-cyan-400 font-semibold mb-2">Costituzione</h3>
-                <ul className="list-disc list-inside space-y-1 ml-2">
-                  <li>1 - Fragile</li>
-                  <li>2 - Normale</li>
-                  <li>3 - Resistente</li>
-                  <li>4 - Molto resistente</li>
-                  <li>5 - Indistruttibile</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          {/* Sezione 2: Caratteristiche Mentali */}
-          <div className="border-b border-cyan-600/20 pb-6">
-            <h2 className="text-lg font-bold text-cyan-300 mb-4">Caratteristiche Mentali</h2>
-            <div className="space-y-4 text-cyan-200 text-sm">
-              <div id="intelligenza">
-                <h3 className="text-cyan-400 font-semibold mb-2">Intelligenza</h3>
-                <ul className="list-disc list-inside space-y-1 ml-2">
-                  <li>1 - Limitato</li>
-                  <li>2 - Normale</li>
-                  <li>3 - Brillante</li>
-                  <li>4 - Geniale</li>
-                  <li>5 - Genio assoluto</li>
-                </ul>
-              </div>
-              
-              <div id="prontezza">
-                <h3 className="text-cyan-400 font-semibold mb-2">Prontezza</h3>
-                <ul className="list-disc list-inside space-y-1 ml-2">
-                  <li>1 - Lento</li>
-                  <li>2 - Normale</li>
-                  <li>3 - Veloce</li>
-                  <li>4 - Fulmineo</li>
-                  <li>5 - Istantaneo</li>
-                </ul>
-              </div>
-              
-              <div id="intuito">
-                <h3 className="text-cyan-400 font-semibold mb-2">Intuito</h3>
-                <ul className="list-disc list-inside space-y-1 ml-2">
-                  <li>1 - Distratto</li>
-                  <li>2 - Attento</li>
-                  <li>3 - Ricettivo</li>
-                  <li>4 - Intuitivo</li>
-                  <li>5 - Chiaroveggente</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          {/* Sezione 3: Caratteristiche Sociali */}
-          <div className="border-b border-cyan-600/20 pb-6">
-            <h2 className="text-lg font-bold text-cyan-300 mb-4">Caratteristiche Sociali</h2>
-            <div className="space-y-4 text-cyan-200 text-sm">
-              <div id="carisma">
-                <h3 className="text-cyan-400 font-semibold mb-2">Carisma</h3>
-                <ul className="list-disc list-inside space-y-1 ml-2">
-                  <li>1 - Antipatico</li>
-                  <li>2 - Normale</li>
-                  <li>3 - Affascinante</li>
-                  <li>4 - Magnetico</li>
-                  <li>5 - Irresistibile</li>
-                </ul>
-              </div>
-              
-              <div id="autocontrollo">
-                <h3 className="text-cyan-400 font-semibold mb-2">Autocontrollo</h3>
-                <ul className="list-disc list-inside space-y-1 ml-2">
-                  <li>1 - Impulsivo</li>
-                  <li>2 - Normale</li>
-                  <li>3 - Disciplinato</li>
-                  <li>4 - Imperturbabile</li>
-                  <li>5 - Zen totale</li>
-                </ul>
-              </div>
-              
-              <div id="sanguefreddo">
-                <h3 className="text-cyan-400 font-semibold mb-2">Sangue Freddo</h3>
-                <ul className="list-disc list-inside space-y-1 ml-2">
-                  <li>1 - Codardo</li>
-                  <li>2 - Normale</li>
-                  <li>3 - Coraggioso</li>
-                  <li>4 - Impavido</li>
-                  <li>5 - Temerario</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          {/* Sezione 4: Regole Generali */}
-          <div className="pb-6">
-            <h2 className="text-lg font-bold text-cyan-300 mb-4">Regole Generali</h2>
-            <div className="space-y-3 text-cyan-200 text-sm">
-              <div className="bg-gray-800/50 rounded-lg p-4 border border-cyan-600/20">
-                <h3 className="text-cyan-400 font-semibold mb-2">Sistema di Punti</h3>
-                <p>Ogni personaggio inizia con 1 punto in ogni caratteristica. Hai 9 punti aggiuntivi da distribuire, con un massimo di 3 punti per caratteristica.</p>
-              </div>
-              
-              <div className="bg-gray-800/50 rounded-lg p-4 border border-cyan-600/20">
-                <h3 className="text-cyan-400 font-semibold mb-2">Tiri di Dado</h3>
-                <p>Il sistema utilizza un dado a 10 facce (d10). Il valore della caratteristica determina il numero di dadi da lanciare nelle prove.</p>
-              </div>
-              
-              <div className="bg-gray-800/50 rounded-lg p-4 border border-cyan-600/20">
-                <h3 className="text-cyan-400 font-semibold mb-2">Successi e Fallimenti</h3>
-                <p>Ogni risultato di 7 o superiore conta come un successo. Il numero di successi determina il grado di riuscita dell'azione.</p>
-              </div>
-              
-              <div className="bg-gray-800/50 rounded-lg p-4 border border-cyan-600/20">
-                <h3 className="text-cyan-400 font-semibold mb-2">Combattimento</h3>
-                <p>Le azioni di combattimento utilizzano combinazioni di caratteristiche. Ad esempio, un attacco fisico potrebbe richiedere Forza + Destrezza.</p>
-              </div>
-            </div>
-          </div>
+      <div className="flex h-[calc(100%-60px)]">
+        <div className="w-48 border-r border-cyan-700 p-4 space-y-1 text-sm">
+          <button onClick={() => setSection('caratteristiche')} className={itemClasses('caratteristiche')}>Caratteristiche</button>
+          <button onClick={() => setSection('abilita')} className={itemClasses('abilita')}>Abilità</button>
+          <button onClick={() => setSection('creazione')} className={itemClasses('creazione')}>Creazione PG</button>
+          <button onClick={() => setSection('regole')} className={itemClasses('regole')}>Regole</button>
+        </div>
+        <div className="scrollable-content flex-1 overflow-y-auto p-6 text-cyan-200 text-sm">
+          {renderContent()}
         </div>
       </div>
     </div>

--- a/frontend/src/components/LoginModal.jsx
+++ b/frontend/src/components/LoginModal.jsx
@@ -101,8 +101,11 @@ const LoginModal = ({
         rememberMe 
       });
       
-      // Salva il token
+      // Salva il token e il ruolo
       localStorage.setItem('token', response.data.token);
+      if (response.data.user?.role) {
+        localStorage.setItem('role', response.data.user.role);
+      }
       
       // Se c'era una penalità, rimuovila dopo login successo
       localStorage.removeItem('forceLogoutTime');

--- a/frontend/src/components/land/ManagementModal.jsx
+++ b/frontend/src/components/land/ManagementModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { X, Plus, Edit3, Trash2, Save, Map, MapPin, Image, FileText, AlertTriangle } from 'lucide-react';
 import api from '../../api';
+import { loadDocumentation, saveDocumentation } from '../../data/documentation';
 
 function ManagementModal({
   onClose,
@@ -13,11 +14,13 @@ function ManagementModal({
   zIndex,
   onMapUpdate
 }) {
+  const [activeMenu, setActiveMenu] = useState('map');
   const [activeTab, setActiveTab] = useState('zones');
   const [zones, setZones] = useState({});
   const [loading, setLoading] = useState(true);
   const [editingZone, setEditingZone] = useState(null);
   const [editingLocation, setEditingLocation] = useState(null);
+  const [documentationData, setDocumentationData] = useState(loadDocumentation());
   const [newZone, setNewZone] = useState({ name: '', description: '' });
   const [newLocation, setNewLocation] = useState({
     name: '',
@@ -166,10 +169,15 @@ function ManagementModal({
       const updatedZones = { ...zones };
       delete updatedZones[zoneName].places[locationName];
       setZones(updatedZones);
-      
+
       // Notifica aggiornamento
       if (onMapUpdate) onMapUpdate();
     }
+  };
+
+  const handleSaveDocumentation = () => {
+    saveDocumentation(documentationData);
+    alert('Documentazione salvata');
   };
 
   const handleMouseDown = (e) => {
@@ -228,24 +236,87 @@ function ManagementModal({
         </button>
       </div>
 
-      {/* Tabs */}
+      {/* Menu */}
       <div className="flex border-b border-gray-700">
-        <button 
-          onClick={() => setActiveTab('zones')}
-          className={`px-4 py-2 text-sm font-medium ${activeTab === 'zones' ? 'text-red-400 border-b-2 border-red-400' : 'text-gray-400 hover:text-gray-300'}`}
+        <button
+          onClick={() => setActiveMenu('documentation')}
+          className={`px-4 py-2 text-sm font-medium ${activeMenu === 'documentation' ? 'text-red-400 border-b-2 border-red-400' : 'text-gray-400 hover:text-gray-300'}`}
+        >
+          <FileText className="w-4 h-4 inline mr-2" />
+          Modifica Documentazione
+        </button>
+        <button
+          onClick={() => setActiveMenu('map')}
+          className={`px-4 py-2 text-sm font-medium ${activeMenu === 'map' ? 'text-red-400 border-b-2 border-red-400' : 'text-gray-400 hover:text-gray-300'}`}
         >
           <Map className="w-4 h-4 inline mr-2" />
-          Gestione Zone
-        </button>
-        <button 
-          onClick={() => setActiveTab('locations')}
-          className={`px-4 py-2 text-sm font-medium ${activeTab === 'locations' ? 'text-red-400 border-b-2 border-red-400' : 'text-gray-400 hover:text-gray-300'}`}
-        >
-          <MapPin className="w-4 h-4 inline mr-2" />
-          Gestione Location
+          Modifica Mappa
         </button>
       </div>
 
+      {activeMenu === 'map' && (
+        <div className="flex border-b border-gray-700">
+          <button
+            onClick={() => setActiveTab('zones')}
+            className={`px-4 py-2 text-sm font-medium ${activeTab === 'zones' ? 'text-red-400 border-b-2 border-red-400' : 'text-gray-400 hover:text-gray-300'}`}
+          >
+            <Map className="w-4 h-4 inline mr-2" />
+            Gestione Zone
+          </button>
+          <button
+            onClick={() => setActiveTab('locations')}
+            className={`px-4 py-2 text-sm font-medium ${activeTab === 'locations' ? 'text-red-400 border-b-2 border-red-400' : 'text-gray-400 hover:text-gray-300'}`}
+          >
+            <MapPin className="w-4 h-4 inline mr-2" />
+            Gestione Location
+          </button>
+        </div>
+      )}
+
+      {activeMenu === 'documentation' && (
+        <div className="scrollable-content p-6 h-[calc(100%-140px)] overflow-y-auto custom-scrollbar space-y-4">
+          <div>
+            <label className="text-red-300 text-sm block mb-1">Caratteristiche</label>
+            <textarea
+              className="w-full bg-gray-700 text-red-100 px-3 py-2 rounded text-sm h-24 resize-none"
+              value={documentationData.caratteristiche}
+              onChange={(e) => setDocumentationData({ ...documentationData, caratteristiche: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="text-red-300 text-sm block mb-1">Abilità</label>
+            <textarea
+              className="w-full bg-gray-700 text-red-100 px-3 py-2 rounded text-sm h-24 resize-none"
+              value={documentationData.abilita}
+              onChange={(e) => setDocumentationData({ ...documentationData, abilita: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="text-red-300 text-sm block mb-1">Creazione Personaggio</label>
+            <textarea
+              className="w-full bg-gray-700 text-red-100 px-3 py-2 rounded text-sm h-24 resize-none"
+              value={documentationData.creazione}
+              onChange={(e) => setDocumentationData({ ...documentationData, creazione: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="text-red-300 text-sm block mb-1">Regole</label>
+            <textarea
+              className="w-full bg-gray-700 text-red-100 px-3 py-2 rounded text-sm h-24 resize-none"
+              value={documentationData.regole}
+              onChange={(e) => setDocumentationData({ ...documentationData, regole: e.target.value })}
+            />
+          </div>
+          <button
+            onClick={handleSaveDocumentation}
+            className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white rounded text-sm"
+          >
+            <Save className="w-4 h-4 inline mr-2" />Salva
+          </button>
+        </div>
+      )}
+
+      {activeMenu === 'map' && (
       <div className="scrollable-content p-6 h-[calc(100%-140px)] overflow-y-auto custom-scrollbar">
         {activeTab === 'zones' && (
           <div className="space-y-6">

--- a/frontend/src/components/land/SidebarSinistra.jsx
+++ b/frontend/src/components/land/SidebarSinistra.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Briefcase, DollarSign, ShoppingCart, BookOpen, FileText, Settings, MessageSquare, Home, RefreshCw, User, LogOut } from 'lucide-react';
 
-export default function SidebarSinistra({ 
-  onOpenDocs, 
-  onOpenSheet, 
-  onOpenManagement, 
-  onRefresh, 
-  onNormalLogout 
+export default function SidebarSinistra({
+  onOpenDocs,
+  onOpenSheet,
+  onOpenManagement,
+  onRefresh,
+  onNormalLogout,
+  isAdmin
 }) {
   const handleRefreshClick = () => {
     // Animazione del bottone
@@ -52,13 +53,15 @@ export default function SidebarSinistra({
           <button onClick={onOpenSheet} className="flex items-center gap-3 w-full text-left hover:text-cyan-100 transition-colors">
             <User className="w-4 h-4" /> Scheda Personaggio
           </button>
-          <button 
-            onClick={onOpenManagement} 
-            className="flex items-center gap-3 w-full text-left text-red-400 hover:text-red-300 transition-colors"
-            title="Console di gestione - Solo Admin"
-          >
-            <Settings className="w-4 h-4" /> Gestione
-          </button>
+          {isAdmin && (
+            <button
+              onClick={onOpenManagement}
+              className="flex items-center gap-3 w-full text-left text-red-400 hover:text-red-300 transition-colors"
+              title="Console di gestione - Solo Admin"
+            >
+              <Settings className="w-4 h-4" /> Gestione
+            </button>
+          )}
         </div>
       </div>
       

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -15,6 +15,7 @@ export const UserProvider = ({ children }) => {
 
   const logout = () => {
     localStorage.removeItem('token');
+    localStorage.removeItem('role');
     setToken(null);
     navigate('/');
   };

--- a/frontend/src/data/documentation.js
+++ b/frontend/src/data/documentation.js
@@ -1,0 +1,24 @@
+const defaultDocumentation = {
+  caratteristiche: `\n### Caratteristiche\nDefiniscono le doti innate del personaggio.`,
+  abilita: `\n### Abilit\u00e0\nRappresentano l'esperienza e l'addestramento.`,
+  creazione: `\n### Creazione del Personaggio\nDistribuisci 9 punti tra le caratteristiche di base, con un massimo di 3 per caratteristica.`,
+  regole: `\n### Regole Generali\nUtilizza un dado a 10 facce. Ogni risultato di 7 o pi\u00f9 è un successo.`
+};
+
+export function loadDocumentation() {
+  const stored = localStorage.getItem('documentationData');
+  if (stored) {
+    try {
+      return JSON.parse(stored);
+    } catch (e) {
+      console.error('Errore parsing documentazione:', e);
+    }
+  }
+  return { ...defaultDocumentation };
+}
+
+export function saveDocumentation(data) {
+  localStorage.setItem('documentationData', JSON.stringify(data));
+}
+
+export default defaultDocumentation;

--- a/frontend/src/pages/Land.jsx
+++ b/frontend/src/pages/Land.jsx
@@ -17,6 +17,8 @@ export default function Land() {
   const navigate = useNavigate();
   const { logout } = useUser();
   const { logoutPenalty, connectionLost, connectionRestored } = useGameNotifications();
+
+  const isAdmin = localStorage.getItem('role') === 'admin';
   
   // Stati per i modali
   const [showDocumentation, setShowDocumentation] = useState(false);
@@ -185,12 +187,13 @@ export default function Land() {
 
       {/* Layout 3 colonne */}
       <div className="flex h-[calc(100%-3rem)]">
-        <SidebarSinistra 
-          onOpenDocs={() => setShowDocumentation(true)} 
-          onOpenSheet={() => setShowSheet(true)} 
+        <SidebarSinistra
+          onOpenDocs={() => setShowDocumentation(true)}
+          onOpenSheet={() => setShowSheet(true)}
           onOpenManagement={() => setShowManagement(true)}
           onRefresh={handleRefresh}
           onNormalLogout={handleNormalLogout}
+          isAdmin={isAdmin}
         />
         <ColonnaCentrale key={lastRefresh} />
         <EodumLandPage 


### PR DESCRIPTION
## Summary
- include `role` in login response
- store user role on login and remove on logout
- show management controls only for admins
- make documentation content editable via new management tab
- display updated documentation modal with selectable sections

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68444ec5423c832281ba754a52608beb