### PR TITLE
Fix missing Gestione button in land

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -43,6 +43,10 @@ app.listen(PORT, async () => {
 
     if (created) {
       console.log('✅ Utente admin creato');
+    } else if (admin.role !== 'admin') {
+      admin.role = 'admin';
+      await admin.save();
+      console.log('🔄 Utente admin aggiornato a ruolo admin');
     } else {
       console.log('ℹ️ Utente admin già esistente');
     }

--- a/frontend/src/pages/Land.jsx
+++ b/frontend/src/pages/Land.jsx
@@ -174,9 +174,14 @@ export default function Land() {
           <button className="px-3 py-1 bg-gray-800/50 border border-blue-600/50 rounded text-sm text-blue-400">
             Bacheche ON/OFF
           </button>
-          <button className="px-3 py-1 bg-gray-800/50 border border-purple-600/50 rounded text-sm text-purple-300">
-            Admin
-          </button>
+          {isAdmin && (
+            <button
+              onClick={() => setShowManagement(true)}
+              className="px-3 py-1 bg-gray-800/50 border border-purple-600/50 rounded text-sm text-purple-300"
+            >
+              Gestione
+            </button>
+          )}
           
           {/* Indicatore ultimo refresh */}
           <div className="text-xs text-cyan-500">


### PR DESCRIPTION
## Summary
- enable management console access directly from the Land top bar
- ensure the `admin@eodum.it` account always has admin role

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in frontend *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684461ca50dc8322b2a576ed3f5cafc8