### PR TITLE
Fix login API URL

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,17 @@
 import axios from 'axios';
 
+// Determine the API base URL.
+// 1. If VITE_API_URL is provided use that value.
+// 2. When running locally fall back to the development server.
+// 3. In production assume the frontend is served from the same domain
+//    as the backend and use a relative path.
+const defaultApiUrl =
+  window.location.hostname === 'localhost'
+    ? 'http://localhost:4000/api'
+    : '/api';
+
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:4000/api',
+  baseURL: import.meta.env.VITE_API_URL || defaultApiUrl,
   headers: {
     'Content-Type': 'application/json'
   }


### PR DESCRIPTION
## Summary
- support local or production backend by detecting hostname

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in backend *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684535fbe0c88322967443eddecf26bc