### PR TITLE
Fix .gitignore merge conflict markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 backend/node_modules/
 backend/.env
 logs/
-<<<<<<< HEAD
 *.log
-=======
-*.log
->>>>>>> a6b45c06a5add896ae08af2983c813c7671bd44c


### PR DESCRIPTION
## Summary
- clean up leftover merge conflict markers in `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684551f4b5ec8322b9a24792163fe752