### PR TITLE
Add user info endpoint and hook

### DIFF
--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -4,6 +4,7 @@ const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
 const { User } = require('../models');
 const { generateToken } = require('../utils/jwtUtils');
+const authMiddleware = require('../middleware/authMiddleware');
 
 // Login
 router.post('/login', async (req, res) => {
@@ -60,6 +61,12 @@ router.post('/logout', async (req, res) => {
     console.error("Errore durante il logout:", error);
     res.status(500).json({ message: "Errore durante il logout" });
   }
+});
+
+// Get current user info
+router.get('/me', authMiddleware, async (req, res) => {
+  const { id, nome, cognome, role, current_location } = req.user;
+  res.json({ id, nome, cognome, role, location: current_location });
 });
 
 module.exports = router;

--- a/frontend/src/hooks/useUserData.js
+++ b/frontend/src/hooks/useUserData.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import api from '../api';
+
+export default function useUserData(onRoleChange) {
+  useEffect(() => {
+    const fetchUserData = async () => {
+      const hasRole = localStorage.getItem('role');
+      if (!hasRole) {
+        try {
+          const res = await api.get('/auth/me');
+          if (res.data && res.data.role) {
+            localStorage.setItem('role', res.data.role);
+            if (onRoleChange) onRoleChange(res.data.role);
+          }
+        } catch (err) {
+          console.error('Errore recupero dati utente:', err);
+        }
+      }
+    };
+
+    fetchUserData();
+  }, [onRoleChange]);
+}

--- a/frontend/src/pages/Land.jsx
+++ b/frontend/src/pages/Land.jsx
@@ -12,13 +12,24 @@ import { useUser } from '../context/UserContext';
 import { useGameNotifications } from '../components/NotificationSystem';
 import { getLogoutPenaltyTime, setLogoutPenalty, formatTime } from '../utils/gameUtils';
 import api from '../api';
+import useUserData from '../hooks/useUserData';
 
 export default function Land() {
   const navigate = useNavigate();
   const { logout } = useUser();
   const { logoutPenalty, connectionLost, connectionRestored } = useGameNotifications();
 
-  const isAdmin = localStorage.getItem('role') === 'admin';
+  const [isAdmin, setIsAdmin] = useState(localStorage.getItem('role') === 'admin');
+
+  // Recupera dati utente se mancano in localStorage
+  useUserData((role) => setIsAdmin(role === 'admin'));
+
+  useEffect(() => {
+    const checkRole = () => setIsAdmin(localStorage.getItem('role') === 'admin');
+    window.addEventListener('storage', checkRole);
+    checkRole();
+    return () => window.removeEventListener('storage', checkRole);
+  }, []);
   
   // Stati per i modali
   const [showDocumentation, setShowDocumentation] = useState(false);


### PR DESCRIPTION
## Summary
- expose `/api/auth/me` to retrieve role from token
- add `useUserData` hook to load user info on the frontend
- show admin panel when role is retrieved

## Testing
- `npm test` (backend) – fails: Error: no test specified
- `npm test` (frontend) – fails: Missing script `test`


------
https://chatgpt.com/codex/tasks/task_e_684557beda708322ac1a38ed2edc982f